### PR TITLE
ログイン保存促し＋公開ページをスマホで全体表示に

### DIFF
--- a/public_html/admin/lib/reservation.php
+++ b/public_html/admin/lib/reservation.php
@@ -360,7 +360,7 @@ function res_render_html(array $data): string
 <html lang="ja">
 <head>
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=740">
 <title>{$titleH}</title>
 <style>
   body { font-family: "遊ゴシック", "Hiragino Sans", sans-serif; margin: 16px; color:#333; }

--- a/public_html/admin/login.php
+++ b/public_html/admin/login.php
@@ -40,12 +40,12 @@ $h = fn($s) => htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
 </style>
 </head>
 <body>
-  <form class="box" method="post" autocomplete="off">
+  <form class="box" method="post" autocomplete="on">
     <h1>管理者ログイン</h1>
     <label for="user">管理者ID</label>
-    <input type="text" id="user" name="user" autofocus>
+    <input type="text" id="user" name="user" autocomplete="username" autofocus>
     <label for="pass">パスワード</label>
-    <input type="password" id="pass" name="pass">
+    <input type="password" id="pass" name="pass" autocomplete="current-password">
     <input type="hidden" name="csrf" value="<?= $h($csrf) ?>">
     <div class="err"><?= $h($error) ?></div>
     <button type="submit">ログイン</button>


### PR DESCRIPTION
- login.php: autocomplete を有効化（username/current-password）し、 Googleパスワードマネージャー等が保存を促すように
- reservation.php: viewport を width=740 の固定幅にし、スマホでも 表全体が縮小されて1画面に収まる（従来のPC的な全体表示）ように