### PR TITLE
中止連絡UIの文言整理＋キャンセル反映に注意書きを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# 秘密情報・ローカル設定（公開フォルダの外に置く想定／絶対にコミットしない）
+/cancel_config.php
+/admin_config.php
+public_html/cancel_config.php
+public_html/api/cancel_config.php
+public_html/admin/admin_config.php
+
+# ローカルの予約・中止データ（PHPが生成。正データは本番サーバー側）
+/reservation_data/
+/cancel_data/
+public_html/api/cancel_data/
+
+# ローカル確認用の一時ファイル
+/_preview*.html
+/_gen_preview.php

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -317,7 +317,7 @@
 
         todayDiv.innerHTML =
           `<h3>本日（${dateStr}）のコート予約状況</h3>` +
-          `<p class="cancel-help">雨・熱中症・雷・強風などで中止する場合は、下の表の<strong>時間帯のマス</strong>をクリックしてください（A面・B面・時間帯ごとに登録できます）。中止済みのマスをクリックするとキャンセルした人を確認できます。</p>` +
+          `<p class="cancel-help">雨・熱中症アラートなどでコートキャンセルした場合は、下の表の<strong>時間帯のマス</strong>をクリックしてください。キャンセル済みのマスをクリックするとキャンセルした人を確認できます。</p>` +
           `<div id="booking-list">読み込み中…</div>`;
         const list = document.getElementById('booking-list');
 
@@ -400,7 +400,8 @@
           .map(r => `<button type="button" class="reason-btn" data-reason="${r.key}">${r.label}</button>`)
           .join('');
         box.innerHTML = `
-          <div class="cancel-dialog-title">コートを中止にする</div>
+          <div class="cancel-dialog-title">キャンセル反映</div>
+          <p class="cancel-dialog-note">体育館へ電話し、コート代還付が可能である事を確認したうえで、キャンセル手続きを行ってからキャンセル登録を行ってください</p>
           <div class="cancel-dialog-target">${slotInfoLine(td)}</div>
           <label class="cancel-field-label">理由</label>
           <div class="reason-btn-group">${reasonBtns}</div>
@@ -445,7 +446,7 @@
       function openViewDialog(td, entry) {
         const box = buildOverlay();
         box.innerHTML = `
-          <div class="cancel-dialog-title">このコートは中止です</div>
+          <div class="cancel-dialog-title">キャンセル取消</div>
           <div class="cancel-dialog-target">${slotInfoLine(td)}</div>
           <div class="cancel-view">
             <div><span class="view-key">理由</span>${reasonLabel(entry.reason)}</div>
@@ -454,13 +455,13 @@
             <div><span class="view-key">登録時刻</span>${escapeHtml(entry.at || '')}</div>
           </div>
           <div class="cancel-clear-area">
-            <label class="cancel-field-label">中止を取り消す場合は合言葉を入力</label>
+            <label class="cancel-field-label">合言葉 <span class="req">必須</span></label>
             <input type="password" id="clear-pw" class="cancel-input" autocomplete="off">
           </div>
           <div class="cancel-msg" id="cancel-msg"></div>
           <div class="cancel-dialog-actions">
             <button type="button" class="cancel-cancel-btn" id="dlg-close">閉じる</button>
-            <button type="button" class="cancel-clear-btn" id="dlg-clear">中止を取り消す</button>
+            <button type="button" class="cancel-clear-btn" id="dlg-clear">キャンセルを取り消す</button>
           </div>`;
         box.querySelector('#dlg-close').addEventListener('click', closeDialog);
         box.querySelector('#dlg-clear').addEventListener('click', async () => {

--- a/public_html/styles.css
+++ b/public_html/styles.css
@@ -404,6 +404,18 @@ span a:hover::before {
   margin-bottom: 6px;
 }
 
+.cancel-dialog-note {
+  background: #fff4e5;
+  border: 1px solid #f0c674;
+  border-left: 4px solid #e08e0b;
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin: 0 0 12px;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: #8a5a00;
+}
+
 .cancel-dialog-target {
   display: inline-block;
   background: #f0f0f0;


### PR DESCRIPTION
- ダイアログ名称を「キャンセル反映」「キャンセル取消」に統一
- キャンセル反映に注意書き（体育館へ電話しコート代還付を確認のうえ登録）を追加
- 取消の合言葉ラベルを反映側と同じ「合言葉 必須」に統一
- 案内文・ボタン文言を「中止」→「キャンセル」に整理
- 秘密/ローカルデータを除外する .gitignore を追加