### PR TITLE
中止情報をコート予約状況ページに残す（当日限定を廃止）

### DIFF
--- a/public_html/api/cancel.php
+++ b/public_html/api/cancel.php
@@ -158,6 +158,26 @@ function clean_text($v, int $max): string
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 
 if ($method === 'GET') {
+    // 月指定: その月の全日分の中止をまとめて返す（コート予約状況ページ用・過去分も残す）
+    if (isset($_GET['month'])) {
+        $month = clean_text($_GET['month'], 7);
+        if (!preg_match('/^\d{4}-\d{2}$/', $month)) {
+            http_response_code(400);
+            send_json(['ok' => false, 'error' => 'bad_month', 'message' => 'month は YYYY-MM 形式で指定してください。']);
+        }
+        $data = load_data($dataFile);
+        $out = [];
+        foreach ($data as $d => $day) {
+            if (is_string($d) && strpos($d, $month . '-') === 0 && is_array($day)) {
+                $pruned = prune_day($day);
+                if (count($pruned) > 0) {
+                    $out[$d] = $pruned;
+                }
+            }
+        }
+        send_json(['ok' => true, 'month' => $month, 'cancellations' => (object)$out]);
+    }
+
     $date = isset($_GET['date']) ? clean_text($_GET['date'], 10) : today_key();
     if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
         $date = today_key();

--- a/public_html/js/court-cancel-overlay.js
+++ b/public_html/js/court-cancel-overlay.js
@@ -1,11 +1,11 @@
 /**
- * 月別コート予約状況ページに「本日の中止」を重ねて表示する。
+ * 月別コート予約状況ページに「中止」を重ねて表示する。
  *
  * - このページのURL（.../NEWFORMAT/<年>/coatbooking<月>-<場所>.html）から
  *   年・月・場所を判定する。
- * - 中止は当日分のみ意味を持つため、表示中のページが「今月」のときだけ動作する。
- * - api/cancel.php から本日の中止情報を取得し、本日の行の該当マス（A面/B面×時間帯）を
- *   「中止」（赤）に置き換える。
+ * - api/cancel.php?month=YYYY-MM から「その月の全日分」の中止情報を取得し、
+ *   中止があった各日の行の該当マス（A面/B面×時間帯）を「中止」（赤）に置き換える。
+ * - 当日だけでなく過去の中止もそのまま残るので、予約状況ページが履歴として使える。
  *
  * 既存の予約HTMLには手を加えず、後付けで重ねるだけ。読み込みや通信に失敗しても
  * ページ表示には影響しない（黙って何もしない）。
@@ -16,21 +16,25 @@
   var pageYear = parseInt(m[1], 10);
   var pageMonth = parseInt(m[2], 10);
   var loc = m[3].toLowerCase();
+  var pad = function (n) { return ('0' + n).slice(-2); };
 
-  var now = new Date();
-  // 表示中のページが今月でなければ、本日の中止が載ることはないので何もしない
-  if (now.getFullYear() !== pageYear || (now.getMonth() + 1) !== pageMonth) return;
-
-  var month = now.getMonth() + 1;
-  var day = now.getDate();
-  var dateKey = pageYear + '-' + ('0' + pageMonth).slice(-2) + '-' + ('0' + day).slice(-2);
-
-  // このページは /coatbokking/NEWFORMAT/<年>/ にあるので、公開ルートまで3つ上がる
-  fetch('../../../api/cancel.php?date=' + dateKey, { cache: 'no-store' })
+  // このページの月の中止を「全日分」取得（過去分も含めて予約状況ページに残す）
+  fetch('../../../api/cancel.php?month=' + pageYear + '-' + pad(pageMonth), { cache: 'no-store' })
     .then(function (r) { return r.ok ? r.json() : null; })
     .then(function (j) {
       if (!j || !j.ok || !j.cancellations) return;
-      applyOverlay(j.cancellations[loc] || {});
+      var table = document.querySelector('table.auto-style27');
+      if (!table) return;
+      var trs = Array.prototype.slice.call(table.querySelectorAll('tr'));
+
+      Object.keys(j.cancellations).forEach(function (dateKey) {
+        var parts = dateKey.split('-');
+        if (parts.length !== 3) return;
+        if (parseInt(parts[0], 10) !== pageYear || parseInt(parts[1], 10) !== pageMonth) return;
+        var day = parseInt(parts[2], 10);
+        var byCourt = (j.cancellations[dateKey] || {})[loc];
+        if (byCourt) applyOverlay(trs, pageMonth, day, byCourt);
+      });
     })
     .catch(function () { /* 通信失敗時は何もしない */ });
 
@@ -38,12 +42,8 @@
     return ({ rain: '雨', heat: '熱中症警戒', thunder: '雷', wind: '強風', other: 'その他' })[k] || k;
   }
 
-  function applyOverlay(byCourt) {
+  function applyOverlay(trs, month, day, byCourt) {
     if (!byCourt || (!byCourt.A && !byCourt.B)) return;
-    var table = document.querySelector('table.auto-style27');
-    if (!table) return;
-
-    var trs = Array.prototype.slice.call(table.querySelectorAll('tr'));
     var dateRe = new RegExp(month + '月\\s*' + day + '日');
 
     for (var i = 0; i < trs.length; i++) {
@@ -55,12 +55,12 @@
       }
       if (!matched) continue;
 
-      // 本日の行（A面）と次の行（B面）。トップページの解析と同じ列構成。
+      // 対象日の行（A面）と次の行（B面）。トップページの解析と同じ列構成。
       var tdsA = trs[i].querySelectorAll('td');            // [日付,曜日,A,9-11,11-13,13-15,15-17,メモ]
       var tdsB = trs[i + 1] ? trs[i + 1].querySelectorAll('td') : []; // [B,9-11,11-13,13-15,15-17]
       markCourt(byCourt.A, [tdsA[3], tdsA[4], tdsA[5], tdsA[6]]);
       markCourt(byCourt.B, [tdsB[1], tdsB[2], tdsB[3], tdsB[4]]);
-      break;
+      return;
     }
   }
 


### PR DESCRIPTION
- cancel.php: ?month=YYYY-MM に対応し、その月の全日分の中止を返す （?date= の当日取得は従来どおり）
- court-cancel-overlay.js: 今月・本日限定をやめ、ページの月の 中止があった全日の行に「中止」を重ねる。過去分も予約状況ページに残る。